### PR TITLE
refactor: improve imports

### DIFF
--- a/codeforces/codeforces.py
+++ b/codeforces/codeforces.py
@@ -1,6 +1,10 @@
-import requests, urllib, simplejson
-import random, time
-import queue, threading
+import requests
+import urllib
+import simplejson
+import random
+import time
+import queue
+import threading
 from collections import defaultdict
 
 from utils import database as db

--- a/codeforces/standings.py
+++ b/codeforces/standings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-import requests, threading, time
+import requests
+import threading
+import time
 from collections import defaultdict
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/commands/behavior_settings.py
+++ b/commands/behavior_settings.py
@@ -1,10 +1,7 @@
-import queue, time, random, re
-from collections import defaultdict
 import threading
 
 from utils.util import logger
 from commands import settings
-from telegram import telegram as tg
 
 chatsLock = threading.Lock()
 

--- a/commands/general_settings.py
+++ b/commands/general_settings.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import json
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
 	from telegram.Chat import Chat as ChatClass

--- a/commands/notification_settings.py
+++ b/commands/notification_settings.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
-import json
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
 	from telegram.Chat import Chat
 from utils import database as db
-from telegram import telegram as tg
-from codeforces import codeforces as cf
-from utils import util
 from utils.util import logger
-from commands import bot, settings
+from commands import settings
 
 # constants
 NOTIFY_LEVEL_DESC_SHORT = ["Disabled", "Only Scoreboard", "Scoreboard + SysTest fail", "Scb + SysTest + Upsolve", "All Notifications"]


### PR DESCRIPTION
Improved imports, deleted unused imports.

A linter (for example, Ruff) complains about rule E401 from PEP 8, the Python code formatting standard. It says:
> Imports should usually be written on separate lines.

For example:
```python
import os
import sys
```
Wrong: ```import sys, os```

However you can importing multiple objects from one module:

```python
from module import a, b, c   # good
```

Your code:

```python
import requests, urllib, simplejson   #  E401
import random, time                   #  E401
import queue, threading               # E401
```

Best practice:

```python
import requests
import urllib
import simplejson
import random
import time
import queue
import threading
```